### PR TITLE
Python 3 compatible setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('VERSION', 'rb') as v:
     version = v.read().decode().strip()
 
 with open('README.md', 'rb') as ld:
-    long_description = ld.read().strip()
+    long_description = ld.read().decode().strip()
 
 setup(
     author='Maciej Gol',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 with open('VERSION', 'rb') as v:
-    version = v.read().strip()
+    version = v.read().decode().strip()
 
 with open('README.md', 'rb') as ld:
     long_description = ld.read().strip()


### PR DESCRIPTION
This should allow it to be installed in python 3.4 and 2.7. I have not tested actually using it in py3 yet.
https://github.com/maciej-gol/tenant-schemas-celery/issues/4