### PR TITLE
Output versions used to pass tests

### DIFF
--- a/__app_run_tests
+++ b/__app_run_tests
@@ -18,6 +18,7 @@ run_silently apt install -y libpq-dev tree
 
 run_silently pip install -r /app/requirements.txt django ${TENANT_SCHEMAS}
 run_silently pip install -e .
+pip freeze
 
 cd test_app
 export DJANGO_SETTINGS_MODULE=test_app.settings


### PR DESCRIPTION
Display output from pip freeze because it is helpful to have a record of the package versions tested against when trying to figure out why something is failing