### PR TITLE
Add support for django with multiple databases

### DIFF
--- a/tenant_schemas_celery/app.py
+++ b/tenant_schemas_celery/app.py
@@ -39,16 +39,18 @@ def switch_schema(task, kwargs, **kw):
     if connection.schema_name == schema:
         return
 
+    tenant_databases = task.get_tenant_databases()
+
     if connection.schema_name != get_public_schema_name():
-        for conn in connections.all():
-            conn.set_schema_to_public()
+        for db_name in tenant_databases:
+            connections[db_name].set_schema_to_public()
 
     if schema == get_public_schema_name():
         return
 
     tenant = task.get_tenant_for_schema(schema_name=schema)
-    for conn in connections.all():
-        conn.set_tenant(tenant, include_public=True)
+    for db_name in tenant_databases:
+        connections[db_name].set_tenant(tenant, include_public=True)
 
 
 def restore_schema(task, **kwargs):
@@ -65,8 +67,8 @@ def restore_schema(task, **kwargs):
     if connection.schema_name == schema_name:
         return
 
-    for conn in connections.all():
-        conn.set_schema(schema_name, include_public=include_public)
+    for db_name in task.get_tenant_databases():
+        connections[db_name].set_schema(schema_name, include_public=include_public)
 
 
 task_prerun.connect(

--- a/tenant_schemas_celery/conftest.py
+++ b/tenant_schemas_celery/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+from celery import current_app
+
+
+@pytest.fixture
+def celery_conf():
+    """
+    Fixture allowing to override celery configuration during test,
+    then the fixture will rollback the changes after completion
+    """
+
+    # Makes a shallow copy of the configuration
+    original = current_app.conf
+    new_conf = current_app.config_from_object(dict(original))
+
+    yield new_conf
+
+    current_app.config_from_object(original)

--- a/tenant_schemas_celery/task.py
+++ b/tenant_schemas_celery/task.py
@@ -20,6 +20,16 @@ class TenantTask(Task):
     abstract = True
 
     tenant_cache_seconds = None
+    tenant_databases = None
+
+    @classmethod
+    def get_tenant_databases(cls):
+        """Return the databases where the schema should be switched"""
+        if cls.tenant_databases is not None:
+            return cls.tenant_databases
+        if hasattr(cls.app.conf, "task_tenant_databases") is True:
+            return cls.app.conf.task_tenant_databases
+        return ("default", )
 
     @classmethod
     def tenant_cache(cls):

--- a/test_app/test_app/settings.py
+++ b/test_app/test_app/settings.py
@@ -114,7 +114,27 @@ DATABASES = {
         'TEST': {
             'NAME': 'tenant_celery',
         }
-    }
+    },
+    'otherdb1': {
+        'ENGINE': DB_ENGINE,
+        'HOST': os.environ.get("DATABASE_HOST", "127.0.0.1"),
+        'NAME': 'tenant_celery',
+        'PASSWORD': 'qwe123',
+        'USER': 'tenant_celery',
+        'TEST': {
+            'NAME': 'tenant_celery',
+        }
+    },
+    'otherdb2': {
+        'ENGINE': DB_ENGINE,
+        'HOST': os.environ.get("DATABASE_HOST", "127.0.0.1"),
+        'NAME': 'tenant_celery',
+        'PASSWORD': 'qwe123',
+        'USER': 'tenant_celery',
+        'TEST': {
+            'NAME': 'tenant_celery',
+        }
+    },
 }
 
 # Password validation

--- a/test_app/test_app/urls.py
+++ b/test_app/test_app/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
The changes proposed allow to switch schema for all connections rather than the only default database.

The changes assume that all connections are always on the same schema as the first connection (`'default'`), meaning the tasks are not switching schema during their execution. Thus that we don't need to check all connections whether they are on a different schema or not.

The lines where the assumption is made:
- [app.py:33](https://github.com/maciej-gol/tenant-schemas-celery/blob/5950625aa536e6a0e4d2ca89393c323df29e0d3d/tenant_schemas_celery/app.py#L33)
- [app.py:39](https://github.com/maciej-gol/tenant-schemas-celery/blob/5950625aa536e6a0e4d2ca89393c323df29e0d3d/tenant_schemas_celery/app.py#L39)
- [app.py:42](https://github.com/maciej-gol/tenant-schemas-celery/blob/5950625aa536e6a0e4d2ca89393c323df29e0d3d/tenant_schemas_celery/app.py#L42)
- [app.py:46](https://github.com/maciej-gol/tenant-schemas-celery/blob/5950625aa536e6a0e4d2ca89393c323df29e0d3d/tenant_schemas_celery/app.py#L46)
- [app.py:65](https://github.com/maciej-gol/tenant-schemas-celery/blob/5950625aa536e6a0e4d2ca89393c323df29e0d3d/tenant_schemas_celery/app.py#L65)

Solves https://github.com/maciej-gol/tenant-schemas-celery/issues/52