### PR TITLE
Dependencies versions updated

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
         tenants-app:
           - django-tenants
         celery: ['celery']

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         tenants-app:
           - django-tenants
-        celery: ['celery<5', 'celery']
+        celery: ['celery']
         broker-url:
           - redis://redis:6379/0
           - amqp://guest:guest@rabbitmq:5672/

--- a/test-compose.yml
+++ b/test-compose.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   postgres:
-    image: postgres:10
+    image: postgres:11
     environment:
       - POSTGRES_PASSWORD=qwe123
       - POSTGRES_USER=tenant_celery

--- a/test-compose.yml
+++ b/test-compose.yml
@@ -20,7 +20,7 @@ services:
       driver: "none"
 
   app:
-    image: "python:${PYTHON_VERSION:-3.7}-slim"
+    image: "python:${PYTHON_VERSION:-3.8}-slim"
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
Removed tests for `celery<5`. Support for these expired Aug 2021. https://docs.celeryq.dev/en/master/history/whatsnew-5.1.html#long-term-support-policy

Remove support for Python 3.7, as newest django (4.1) supports Python 3.8+ only