### PR TITLE
Fix potential deadlock during migrations caused by Celery Beat 

### DIFF
--- a/test_app/test_app/shared/models.py
+++ b/test_app/test_app/shared/models.py
@@ -6,6 +6,7 @@ from django_tenants.models import TenantMixin
 
 class Client(TenantMixin):
     name = models.CharField(max_length=16)
+    ready = models.BooleanField(default=False)
 
 
 class Domain(TenantMixin):


### PR DESCRIPTION
When using a subclass of `TenantAwareSchedulerMixin`, there's a risk that very frequent (or just unfortunately timed) celery tasks might cause a deadlock when running migrations for a new tenant. This is specially true for bigger projects with a lot of migrations and new tenants (in our setup, migrations can last more than 30mins).

In order to mitigate this, we need a flag in the tenant model that indicates whether or not the tenant is ready for usage (at least for `beat`, but since `django-tenants` doesn't provide any, the user of the library must configure their projects to change the filtering behaviour of the scheduler based on their own implementation.

The proposed solution adds a configurable filtering dictionary that's picked up by the scheduler and used to filter the queryset of tenants for which it will run migrations.

Adding new tenants then becomes a matter of creating them, running their migrations (either synchronously or asynchronously) and finally setting the flags to start counting them as `ready`. I.E:

```python
# project/settings.py
TENANT_READINESS_FILTER = dict(ready=True)

# somewhere else, i.e: a shell
Tenant = get_tenant_model()

# Creates tenant and runs migrations
new_tenant = Tenant.objects.create(name="Foo", schema_name="foo", ready=False)

# Tenant is created and the schema is ready, but celery beat still doesn't run tasks for it
...

# Mark the tenant as ready
tenant.ready = True
tenant.save()

# Celery beat will start scheduling tasks for that tenant. 
``` 