### PR TITLE
Fix custom task class after introduction of DjangoTask in 5.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         tenants-app:
           - django-tenants
-        celery: ['celery']
+        celery: ['celery', 'celery<5.4']
         broker-url:
           - redis://redis:6379/0
           - amqp://guest:guest@rabbitmq:5672/

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         tenants-app:
           - django-tenants
-        celery: ['celery', 'celery<5.4']
+        celery: ['celery', 'celery<5.5', 'celery<5.4']
         broker-url:
           - redis://redis:6379/0
           - amqp://guest:guest@rabbitmq:5672/

--- a/run-tests
+++ b/run-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PYTHON_VERSION=${PYTHON_VERSION:-3.7}
+export PYTHON_VERSION=${PYTHON_VERSION:-3.8}
 export ADDITIONAL_REQUIREMENTS=${ADDITIONAL_REQUIREMENTS:-django-tenants}
 export BROKER_URL=${BROKER_URL:-amqp://guest:guest@rabbitmq:5672/}
 

--- a/tenant_schemas_celery/app.py
+++ b/tenant_schemas_celery/app.py
@@ -78,6 +78,10 @@ class CeleryApp(Celery):
     registry_cls = 'tenant_schemas_celery.registry:TenantTaskRegistry'
     task_cls = 'tenant_schemas_celery.task:TenantTask'
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("task_cls", self.task_cls)
+        super(CeleryApp, self).__init__(*args, **kwargs)
+
     def create_task_cls(self):
         return self.subclass_with_self(
             self.task_cls,


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/celery/celery/pull/8491 where the custom task class check looks only at the `task_cls` argument to the c-tor, ignoring the class attribute.