### PR TITLE
Subclass DjangoTask instead of Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Usage
    app = TenantAwareCeleryApp()
    app.config_from_object('django.conf:settings')
    app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+   # On Celery >= 5.4, if you want to use DjangoTask
+   from tenant_schemas_celery.app import CeleryApp
+
+   class TenantAwareCeleryApp(CeleryApp):
+      task_cls = 'tenant_schemas_celery.task:TenantDjangoTask'
 ```
 
 This assumes a fresh Celery 5.2.0 application. For previous versions, the key is to create a new `CeleryApp` instance that will be used to access task decorator from.

--- a/run-celery-worker
+++ b/run-celery-worker
@@ -1,5 +1,5 @@
 #!/bin/bash
-. .env/bin/activate
+pyenv activate tenant-schemas-celery
 cd test_app
 export DJANGO_SETTINGS_MODULE=test_app.settings
 

--- a/tenant_schemas_celery/task.py
+++ b/tenant_schemas_celery/task.py
@@ -11,7 +11,7 @@ class SharedTenantCache(SimpleCache):
         super().__init__(storage=_shared_storage)
 
 
-class TenantTask(Task):
+class TenantTaskMixin:
     """ Custom Task class that injects db schema currently used to the task's
         keywords so that the worker can use the same schema.
     """
@@ -66,3 +66,16 @@ class TenantTask(Task):
     def apply(self, args=None, kwargs=None, *arg, **kw):
         self._update_headers(kw)
         return super().apply(args, kwargs, *arg, **kw)
+
+class TenantTask(TenantTaskMixin, Task):
+    ...
+
+
+# DjangoTask requires Celery 5.4. Before then, we can't make it the default.
+try:
+    from celery.contrib.django.task import DjangoTask
+
+    class TenantDjangoTask(TenantTaskMixin, DjangoTask):
+        ...
+except ImportError:
+    pass


### PR DESCRIPTION
Since we require `django-tenants` to be there, any customer will have django installed. We can subclass `DjangoTask` directly and use make any customizations available.

Ref #133 