### PR TITLE
Update db_scheduler.py (ValueError: duplicate periodic task name: 'celery.backend_cleanup'. Previously seen in schema: 'public'.)

### DIFF
--- a/tenant_schemas_celery/db_scheduler.py
+++ b/tenant_schemas_celery/db_scheduler.py
@@ -24,10 +24,10 @@ class TenantAwareModelManager:
         return list(get_tenant_model().objects.values_list("schema_name", flat=True))
 
     def get_schema_names(self) -> list[str]:
-        return [
+        return {
             *self.get_public_schema_name(),
             *self.get_tenant_schema_names(),
-        ]
+        }
 
     def enabled(self) -> list[PeriodicTask]:
         models = []


### PR DESCRIPTION
self.get_tenant_schema_names() returns all schemas which includes also "public" schema  therefore with combination with self.get_public_schema_name() result contains duplicated "public" schema which is causing ValueError: duplicate periodic task name: 'celery.backend_cleanup'. Previously seen in schema: 'public'.

Removing duplicates by converting to set()