### PR TITLE
django-celery-beat 2.8 is now supported

### DIFF
--- a/__app_run_tests
+++ b/__app_run_tests
@@ -16,7 +16,7 @@ function run_silently() {
 run_silently apt update
 run_silently apt install -y libpq-dev tree
 
-run_silently pip install -r /app/requirements.txt django 'django_celery_beat' django_tenants ${ADDITIONAL_REQUIREMENTS}
+run_silently pip install -U -r /app/requirements.txt django 'django_celery_beat' django_tenants ${ADDITIONAL_REQUIREMENTS}
 run_silently pip install -e . 'importlib-metadata<5'
 pip freeze
 

--- a/__app_run_tests
+++ b/__app_run_tests
@@ -16,7 +16,7 @@ function run_silently() {
 run_silently apt update
 run_silently apt install -y libpq-dev tree
 
-run_silently pip install -r /app/requirements.txt django 'django_celery_beat<2.8.0' django_tenants ${ADDITIONAL_REQUIREMENTS}
+run_silently pip install -r /app/requirements.txt django 'django_celery_beat' django_tenants ${ADDITIONAL_REQUIREMENTS}
 run_silently pip install -e . 'importlib-metadata<5'
 pip freeze
 

--- a/test-compose.yml
+++ b/test-compose.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   postgres:
-    image: postgres:13
+    image: postgres:16
     environment:
       - POSTGRES_PASSWORD=qwe123
       - POSTGRES_USER=tenant_celery


### PR DESCRIPTION
This uses the recently introduced `.enabled.models` and `.enabled_models_qs` methods to list all periodic tasks from all of the tenants. The `.enabled_models_qs` logic stays controlled by the `django_celery_beat` libary and we just repeatedly call it within different schema contexts to generate the final list of tasks.

This unblocks support for `django-celery-beat>=2.8`.

Closes #152